### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
 
   linearb:
     needs: [publish]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: "release"
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ await client.AcknowledgeCloudEventsAsync(topicName, eventSubscriptionName, new A
 
 ## License
 
-This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/main/LICENSE.
+This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/main/LICENSE.


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 