### PR TITLE
Add `pull-requests: write` permissions to the jira job

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -8,8 +8,7 @@ on:
 jobs:
   call-workflow-jira:
     uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
-    with:
-      branch_name: ${{ github.head_ref }}
     permissions:
       contents: read
+      pull-requests: write
       id-token: write


### PR DESCRIPTION
We prepare a change to the shared Jira pipeline. This will require write access to the pull request to edit its description.